### PR TITLE
Add highlighting for rspec-its

### DIFF
--- a/Better RSpec.tmLanguage
+++ b/Better RSpec.tmLanguage
@@ -122,7 +122,7 @@
 		<key>example</key>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(it|specify|scenario|example|xit)\b</string>
+			<string>^\s*(it|its|specify|scenario|example|xit)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -167,7 +167,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(it|specify|scenario|example)\s+(.*\S)(?&lt;!do)\s*$</string>
+			<string>^\s*(it|its|specify|scenario|example)\s+(.*\S)(?&lt;!do)\s*$</string>
 			<key>name</key>
 			<string>meta.rspec.pending</string>
 		</dict>
@@ -182,7 +182,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(it|specify|scenario|example)\s*{</string>
+			<string>^\s*(it|its|specify|scenario|example)\s*{</string>
 		</dict>
 
 		<key>other</key>


### PR DESCRIPTION
Make `its` highlighted the same way as `it`, for use with [rspec-its](https://github.com/rspec/rspec-its)