### PR TITLE
Unify example and single-line-example

### DIFF
--- a/Better RSpec.tmLanguage
+++ b/Better RSpec.tmLanguage
@@ -58,10 +58,6 @@
     </dict>
     <dict>
       <key>include</key>
-      <string>#single-line-example</string>
-    </dict>
-    <dict>
-      <key>include</key>
       <string>#pending</string>
     </dict>
     <dict>
@@ -132,7 +128,7 @@
         </dict>
       </dict>
       <key>end</key>
-      <string>\b(do)\s*$</string>
+      <string>\b(do)\s*$|{</string>
       <key>endCaptures</key>
       <dict>
         <key>1</key>
@@ -167,24 +163,10 @@
         </dict>
       </dict>
       <key>match</key>
-      <string>^\s*(it|its|specify|scenario|example)\s+(.*\S)(?&lt;!do)\s*$</string>
+      <string>^\s*(it|its|specify|scenario|example)\s+(.*\S)(?&lt;!do|})\s*$</string>
       <key>name</key>
       <string>meta.rspec.pending</string>
     </dict>
-    <key>single-line-example</key>
-    <dict>
-      <key>captures</key>
-      <dict>
-        <key>1</key>
-        <dict>
-          <key>name</key>
-          <string>keyword.other.rspec.example</string>
-        </dict>
-      </dict>
-      <key>match</key>
-      <string>^\s*(it|its|specify|scenario|example)\s*{</string>
-    </dict>
-
     <key>other</key>
     <dict>
       <key>captures</key>


### PR DESCRIPTION
## Problem

The `its` keyword takes an argument which was not accounted for so lines
like

```
its(:name) { should == "Bob" }
```

was breaking the detection and everything that came after it was not
highlighted properly.
## Solution

First I tried to adjust the `single-line-example` pattern but then there was a collision between `example` and `single-line-example`. Only one was picked up and the other was never activated.

I removed the `single-line-example` pattern and adjusted the `example` and `pending` patterns to recognize the ending of a single line example as well. 
