### PR TITLE
Add boilerplate code and remove require spec_helper

### DIFF
--- a/RspecToggle.py
+++ b/RspecToggle.py
@@ -16,12 +16,24 @@ Do you want to create it?
 """
 
 SPEC_TEMPLATE = """\
-require 'spec_helper'
+RSpec.describe  do
+  describe '' do
+    it do
+    end
+  end
+end
 
 """
 
 RAILS_SPEC_TEMPLATE = """\
 require 'rails_helper'
+
+RSpec.describe  do
+  describe '' do
+    it do
+    end
+  end
+end
 
 """
 


### PR DESCRIPTION
When running `rspec --init`, the `spec_helper.rb` is already required in `.rspec` file via `--require spec_helper`