### PR TITLE
Handle nested dirs and add a little debug

### DIFF
--- a/RspecToggle.py
+++ b/RspecToggle.py
@@ -124,7 +124,7 @@ class RspecToggleCommand(sublime_plugin.WindowCommand):
       os.makedirs(basedir)
 
   def _print_debug(self, *msg):
-    if self._get_setting(sublime.active_window().active_view(), sublime.load_settings('sublime-better-rspec.sublime-settings'), "debug", False):
+    if self._get_setting(sublime.active_window().active_view(), sublime.load_settings('better-rspec.sublime-settings'), "debug", False):
       print(msg)
 
   def _get_filepaths_with_glob(self, root_path: str, file_regex: str):


### PR DESCRIPTION
My spec directory has unit tests nested under a 'nest' directory. This change should handle those simple cases.

I have no other project to test it on, but this works for me.